### PR TITLE
Update config_example.h

### DIFF
--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -1,4 +1,4 @@
-// Ardumower Sunray 
+// Ardumower Sunray V1.0.267 mit Joystickspeed und SpeedParameter installiert.
 // Copyright (c) 2013-2020 by Alexander Grau, Grau GmbH
 // Licensed GPLv3 for open source use
 // or Grau GmbH Commercial License for commercial use (http://grauonline.de/cms2/?page_id=153)
@@ -149,7 +149,6 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define SONARSPEED              0.10 //m/s
 #define DOCKANGULARSPEED        0.25 //rad/s
 #define OBSTACLEAVOIDANCESPEED  0.15 //m/s
-#define GOHOMESPEED             0.59 //m/s
 #define MOTOR_MAX_SPEED         0.50          // limitation for setSpeed value from Sunray-App (0,01 to 0,59m/sec are possible) to avoid to high speed setting by mistake   // SOEW_NEU
 #define MOTOR_MIN_SPEED         0.05          // minimal driving speed
 


### PR DESCRIPTION
### This Version is a fork from the sunray release version 1.0.267 with the following added options:
- **No error if bumper stays permanently triggered**
set bumper error in case of continious triggering (time can be adjusted in config.h "BUMPER_MAX_TRIGGER_TIME".
- **map setSpeed as maximum speed for navigation by joystick from sunray-app**
It is possible to navigate the mower by touch-joystick in sunray-app.
In some cases it could be neccessary to navigate the mower very soften, especially when your connected by wifi to the mower.
If parameter is set to true, the speed value from app will be used for maximum speed by joystick control. To navigate soften, change the speed slider for example to 0.10. If you need to let the mower drive long distance without accurate positioning change the speed slider to 0.30.
- **Adjustable speed and time values in config.h from MrTreeBark**
see "MOW_SPINUPTIME; OVERLOADSPEED; ROTATETOTARGETSPEED; TRACKSLOWSPEED; APPROACHWAYPOINTSPEED; FLOATSPEED; SONARSPEED; DOCKANGULARSPEED; OBSTACLEAVOIDANCESPEED; MOTOR_MAX_SPEED; MOTOR_MIN_SPEED;
- **Map Stanley Control parameters to actual linearspeedset from motor.setlinearangularspeed from MrTreeBark**
